### PR TITLE
Missing tablib import

### DIFF
--- a/smoothness-weblib/src/main/resources/META-INF/tags/date-range.tag
+++ b/smoothness-weblib/src/main/resources/META-INF/tags/date-range.tag
@@ -1,4 +1,5 @@
 <%@tag description="Date Range" pageEncoding="UTF-8" trimDirectiveWhitespaces="true"%>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@attribute name="required" required="false" type="java.lang.Boolean"%>
 <%@attribute name="datetime" required="false" type="java.lang.Boolean"%>
 <%@attribute name="sevenAmOffset" required="false" type="java.lang.Boolean"%>


### PR DESCRIPTION
Results in invalid HTML that is logged, but ignored by most browsers.  The HTML looks like:


```
<select id="date-range" class="datetime-range seven-am-offset">
   <option value="1fiscalyear">Previous Fiscal Year</option>
   <option value="1fiscalyearq4">Previous Fiscal Year Q4</option>
   <option value="1fiscalyearq3">Previous Fiscal Year Q3</option>
   <option value="1fiscalyearq2">Previous Fiscal Year Q2</option>
   <option value="1fiscalyearq1">Previous Fiscal Year Q1</option>
   <option value="1year">Previous Year</option>
   <option value="1month">Previous Month</option>
   <option value="1week">Previous Week (from Wed 7:00)</option>
   <c:if test="true">
   <option value="1ccshift">Previous CC Shift</option>
   </c:if>
   <option value="0fiscalyear">Current Fiscal Year</option>
   <option value="0fiscalyearq4">Current Fiscal Year Q4</option>
   <option value="0fiscalyearq3">Current Fiscal Year Q3</option>
...
```